### PR TITLE
Only compute animation frames when needed to improve performance

### DIFF
--- a/common/src/main/java/io/github/moremcmeta/animationplugin/animate/AnimationComponent.java
+++ b/common/src/main/java/io/github/moremcmeta/animationplugin/animate/AnimationComponent.java
@@ -44,26 +44,22 @@ public final class AnimationComponent {
 
     /**
      * Updates the animation state on tick.
+     * @param currentFrame          current frame of the animated texture (to which all animations write)
+     * @param predefinedFrames      predefined frames in the base texture
+     * @param ticks                 number of ticks that have passed since the last time this method was called
      */
-    public void onTick() {
+    public void onTick(CurrentFrameView currentFrame, List<Frame> predefinedFrames, int ticks) {
         Optional<Long> timeOptional = TIME_GETTER.get();
 
         if (timeOptional.isPresent()) {
             long currentTime = timeOptional.get();
-            int ticksToAdd = Math.floorMod(currentTime - STATE.ticks(), SYNC_TICKS) + TICKS_UNTIL_START;
+            int ticksUntilTime = Math.floorMod(currentTime - STATE.ticks(), SYNC_TICKS) + TICKS_UNTIL_START;
 
-            STATE.tick(ticksToAdd);
+            STATE.tick(ticksUntilTime);
         } else {
-            STATE.tick(1);
+            STATE.tick(ticks);
         }
-    }
 
-    /**
-     * Updates the texture when it is used.
-     * @param currentFrame          current frame of the animated texture (to which all animations write)
-     * @param predefinedFrames      predefined frames in the base texture
-     */
-    public void onUse(CurrentFrameView currentFrame, List<Frame> predefinedFrames) {
         int startIndex = FRAME_INDEX_MAPPER.applyAsInt(STATE.startIndex());
         int endIndex = FRAME_INDEX_MAPPER.applyAsInt(STATE.endIndex());
 

--- a/common/src/main/java/io/github/moremcmeta/animationplugin/animate/AnimationComponent.java
+++ b/common/src/main/java/io/github/moremcmeta/animationplugin/animate/AnimationComponent.java
@@ -43,11 +43,9 @@ public final class AnimationComponent {
     private final int Y_IN_BASE;
 
     /**
-     * Updates the animation on tick.
-     * @param currentFrame          current frame of the animated texture (to which all animations write)
-     * @param predefinedFrames      predefined frames in the base texture
+     * Updates the animation state on tick.
      */
-    public void onTick(CurrentFrameView currentFrame, List<Frame> predefinedFrames) {
+    public void onTick() {
         Optional<Long> timeOptional = TIME_GETTER.get();
 
         if (timeOptional.isPresent()) {
@@ -58,7 +56,14 @@ public final class AnimationComponent {
         } else {
             STATE.tick(1);
         }
+    }
 
+    /**
+     * Updates the texture when it is used.
+     * @param currentFrame          current frame of the animated texture (to which all animations write)
+     * @param predefinedFrames      predefined frames in the base texture
+     */
+    public void onUse(CurrentFrameView currentFrame, List<Frame> predefinedFrames) {
         int startIndex = FRAME_INDEX_MAPPER.applyAsInt(STATE.startIndex());
         int endIndex = FRAME_INDEX_MAPPER.applyAsInt(STATE.endIndex());
 

--- a/common/src/main/java/io/github/moremcmeta/animationplugin/animate/AnimationGroupComponent.java
+++ b/common/src/main/java/io/github/moremcmeta/animationplugin/animate/AnimationGroupComponent.java
@@ -51,25 +51,15 @@ public final class AnimationGroupComponent implements TextureComponent<CurrentFr
     }
 
     @Override
-    public void onTick(CurrentFrameView currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames) {
-        COMPONENTS.forEach((pair) ->
-            pair.getSecond().ifPresentOrElse(
-                    (frames) -> pair.getFirst().onTick(),
-                    () -> pair.getFirst().onTick()
-            )
-        );
-    }
-
-    @Override
-    public void onUse(CurrentFrameView currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames) {
+    public void onTick(CurrentFrameView currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames, int ticks) {
         if (predefinedFrameCache == null) {
             predefinedFrameCache = wrapFrames(predefinedFrames);
         }
 
         COMPONENTS.forEach((pair) ->
                 pair.getSecond().ifPresentOrElse(
-                        (frames) -> pair.getFirst().onUse(currentFrame, frames),
-                        () -> pair.getFirst().onUse(currentFrame, predefinedFrameCache)
+                        (frames) -> pair.getFirst().onTick(currentFrame, frames, ticks),
+                        () -> pair.getFirst().onTick(currentFrame, predefinedFrameCache, ticks)
                 )
         );
     }

--- a/common/src/main/java/io/github/moremcmeta/animationplugin/animate/AnimationGroupComponent.java
+++ b/common/src/main/java/io/github/moremcmeta/animationplugin/animate/AnimationGroupComponent.java
@@ -52,15 +52,25 @@ public final class AnimationGroupComponent implements TextureComponent<CurrentFr
 
     @Override
     public void onTick(CurrentFrameView currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames) {
+        COMPONENTS.forEach((pair) ->
+            pair.getSecond().ifPresentOrElse(
+                    (frames) -> pair.getFirst().onTick(),
+                    () -> pair.getFirst().onTick()
+            )
+        );
+    }
+
+    @Override
+    public void onUse(CurrentFrameView currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames) {
         if (predefinedFrameCache == null) {
             predefinedFrameCache = wrapFrames(predefinedFrames);
         }
 
         COMPONENTS.forEach((pair) ->
-            pair.getSecond().ifPresentOrElse(
-                    (frames) -> pair.getFirst().onTick(currentFrame, frames),
-                    () -> pair.getFirst().onTick(currentFrame, predefinedFrameCache)
-            )
+                pair.getSecond().ifPresentOrElse(
+                        (frames) -> pair.getFirst().onUse(currentFrame, frames),
+                        () -> pair.getFirst().onUse(currentFrame, predefinedFrameCache)
+                )
         );
     }
 

--- a/common/src/test/java/io/github/moremcmeta/animationplugin/animate/AnimationComponentTest.java
+++ b/common/src/test/java/io/github/moremcmeta/animationplugin/animate/AnimationComponentTest.java
@@ -196,7 +196,7 @@ public final class AnimationComponentTest {
                 .build();
 
         expectedException.expect(NullPointerException.class);
-        component.onTick(new MockCurrentFrameView(), makeMockFrames(5));
+        component.onTick();
     }
 
     @Test
@@ -216,9 +216,10 @@ public final class AnimationComponentTest {
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
         while (tick.getAndIncrement() < animationLength) {
-            component.onTick(currentFrameView, makeMockFrames(frames));
+            component.onTick();
         }
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(indexToColor(0), currentFrameView.color(0, 0));
     }
 
@@ -238,9 +239,10 @@ public final class AnimationComponentTest {
 
         int animationLength = 330;
         for (int tick = 0; tick < animationLength; tick++) {
-            component.onTick(currentFrameView, makeMockFrames(frames));
+            component.onTick();
         }
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(80, 50, indexToColor(7), indexToColor(8)),
                 currentFrameView.color(0, 0)
@@ -263,9 +265,10 @@ public final class AnimationComponentTest {
 
         int animationLength = 330;
         for (int tick = 0; tick < animationLength; tick++) {
-            component.onTick(currentFrameView, makeMockFrames(frames));
+            component.onTick();
         }
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(80, 55, indexToColor(7), indexToColor(8)),
                 currentFrameView.color(0, 0)
@@ -288,9 +291,10 @@ public final class AnimationComponentTest {
 
         int animationLength = 330;
         for (int tick = 0; tick < animationLength; tick++) {
-            component.onTick(currentFrameView, makeMockFrames(frames));
+            component.onTick();
         }
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(80, 65, indexToColor(7), indexToColor(8)),
                 currentFrameView.color(0, 0)
@@ -313,8 +317,9 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick(currentFrameView, makeMockFrames(frames));
+        component.onTick();
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(10, 1, indexToColor(0), indexToColor(1)),
                 currentFrameView.color(0, 0)
@@ -337,8 +342,9 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick(currentFrameView, makeMockFrames(frames));
+        component.onTick();
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 indexToColor(0),
                 currentFrameView.color(0, 0)
@@ -361,8 +367,9 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick(currentFrameView, makeMockFrames(frames));
+        component.onTick();
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 15, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -385,8 +392,9 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick(currentFrameView, makeMockFrames(frames));
+        component.onTick();
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 65, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -409,8 +417,9 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick(currentFrameView, makeMockFrames(frames));
+        component.onTick();
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 20, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -433,8 +442,9 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick(currentFrameView, makeMockFrames(frames));
+        component.onTick();
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 30, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -457,8 +467,9 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick(currentFrameView, makeMockFrames(frames));
+        component.onTick();
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 70, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -481,8 +492,9 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick(currentFrameView, makeMockFrames(frames));
+        component.onTick();
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 81, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -505,8 +517,9 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick(currentFrameView, makeMockFrames(frames));
+        component.onTick();
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 15, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -529,8 +542,9 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick(currentFrameView, makeMockFrames(frames));
+        component.onTick();
 
+        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(60, 42, indexToColor(5), indexToColor(6)),
                 currentFrameView.color(0, 0)
@@ -567,9 +581,10 @@ public final class AnimationComponentTest {
 
         int animationLength = 330;
         for (int tick = 0; tick < animationLength; tick++) {
-            component.onTick(currentFrameView, mockFrames);
+            component.onTick();
         }
 
+        component.onUse(currentFrameView, mockFrames);
         assertEquals(
                 INTERPOLATOR.interpolate(80, 50, indexToColor(7), indexToColor(8)),
                 currentFrameView.color(7, 14)

--- a/common/src/test/java/io/github/moremcmeta/animationplugin/animate/AnimationComponentTest.java
+++ b/common/src/test/java/io/github/moremcmeta/animationplugin/animate/AnimationComponentTest.java
@@ -196,7 +196,7 @@ public final class AnimationComponentTest {
                 .build();
 
         expectedException.expect(NullPointerException.class);
-        component.onTick();
+        component.onTick(new MockCurrentFrameView(), makeMockFrames(5), 1);
     }
 
     @Test
@@ -216,10 +216,9 @@ public final class AnimationComponentTest {
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
         while (tick.getAndIncrement() < animationLength) {
-            component.onTick();
+            component.onTick(currentFrameView, makeMockFrames(frames), 1);
         }
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(indexToColor(0), currentFrameView.color(0, 0));
     }
 
@@ -239,10 +238,9 @@ public final class AnimationComponentTest {
 
         int animationLength = 330;
         for (int tick = 0; tick < animationLength; tick++) {
-            component.onTick();
+            component.onTick(currentFrameView, makeMockFrames(frames), 1);
         }
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(80, 50, indexToColor(7), indexToColor(8)),
                 currentFrameView.color(0, 0)
@@ -265,10 +263,9 @@ public final class AnimationComponentTest {
 
         int animationLength = 330;
         for (int tick = 0; tick < animationLength; tick++) {
-            component.onTick();
+            component.onTick(currentFrameView, makeMockFrames(frames), 1);
         }
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(80, 55, indexToColor(7), indexToColor(8)),
                 currentFrameView.color(0, 0)
@@ -291,10 +288,9 @@ public final class AnimationComponentTest {
 
         int animationLength = 330;
         for (int tick = 0; tick < animationLength; tick++) {
-            component.onTick();
+            component.onTick(currentFrameView, makeMockFrames(frames), 1);
         }
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(80, 65, indexToColor(7), indexToColor(8)),
                 currentFrameView.color(0, 0)
@@ -317,9 +313,8 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick();
+        component.onTick(currentFrameView, makeMockFrames(frames), 1);
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(10, 1, indexToColor(0), indexToColor(1)),
                 currentFrameView.color(0, 0)
@@ -342,9 +337,8 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick();
+        component.onTick(currentFrameView, makeMockFrames(frames), 1);
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 indexToColor(0),
                 currentFrameView.color(0, 0)
@@ -367,9 +361,8 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick();
+        component.onTick(currentFrameView, makeMockFrames(frames), 1);
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 15, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -392,9 +385,8 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick();
+        component.onTick(currentFrameView, makeMockFrames(frames), 1);
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 65, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -417,9 +409,8 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick();
+        component.onTick(currentFrameView, makeMockFrames(frames), 1);
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 20, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -442,9 +433,8 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick();
+        component.onTick(currentFrameView, makeMockFrames(frames), 1);
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 30, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -467,9 +457,8 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick();
+        component.onTick(currentFrameView, makeMockFrames(frames), 1);
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 70, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -492,9 +481,8 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick();
+        component.onTick(currentFrameView, makeMockFrames(frames), 1);
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 81, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -517,9 +505,8 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick();
+        component.onTick(currentFrameView, makeMockFrames(frames), 1);
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(90, 15, indexToColor(8), indexToColor(9)),
                 currentFrameView.color(0, 0)
@@ -542,9 +529,8 @@ public final class AnimationComponentTest {
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
 
-        component.onTick();
+        component.onTick(currentFrameView, makeMockFrames(frames), 1);
 
-        component.onUse(currentFrameView, makeMockFrames(frames));
         assertEquals(
                 INTERPOLATOR.interpolate(60, 42, indexToColor(5), indexToColor(6)),
                 currentFrameView.color(0, 0)
@@ -581,10 +567,9 @@ public final class AnimationComponentTest {
 
         int animationLength = 330;
         for (int tick = 0; tick < animationLength; tick++) {
-            component.onTick();
+            component.onTick(currentFrameView, mockFrames, 1);
         }
 
-        component.onUse(currentFrameView, mockFrames);
         assertEquals(
                 INTERPOLATOR.interpolate(80, 50, indexToColor(7), indexToColor(8)),
                 currentFrameView.color(7, 14)

--- a/common/src/test/java/io/github/moremcmeta/animationplugin/animate/AnimationGroupComponentTest.java
+++ b/common/src/test/java/io/github/moremcmeta/animationplugin/animate/AnimationGroupComponentTest.java
@@ -88,6 +88,7 @@ public final class AnimationGroupComponentTest {
             groupComponent.onTick(currentFrameView, persistentFrames);
         }
 
+        groupComponent.onUse(currentFrameView, persistentFrames);
         assertEquals(
                 INTERPOLATOR.interpolate(80, 50, indexToColor(7), indexToColor(8)),
                 currentFrameView.color(0, 0)
@@ -131,6 +132,7 @@ public final class AnimationGroupComponentTest {
             groupComponent.onTick(currentFrameView, persistentFrames);
         }
 
+        groupComponent.onUse(currentFrameView, persistentFrames);
         assertEquals(
                 INTERPOLATOR.interpolate(80, 50, indexToColor(17), indexToColor(18)),
                 currentFrameView.color(0, 0)
@@ -216,6 +218,7 @@ public final class AnimationGroupComponentTest {
             groupComponent.onTick(currentFrameView, persistentFrames);
         }
 
+        groupComponent.onUse(currentFrameView, persistentFrames);
         assertEquals(
                 INTERPOLATOR.interpolate(80, 50, indexToColor(7), indexToColor(8)),
                 currentFrameView.color(9, 19)

--- a/common/src/test/java/io/github/moremcmeta/animationplugin/animate/AnimationGroupComponentTest.java
+++ b/common/src/test/java/io/github/moremcmeta/animationplugin/animate/AnimationGroupComponentTest.java
@@ -85,10 +85,9 @@ public final class AnimationGroupComponentTest {
 
         int animationLength = 330;
         for (int tick = 0; tick < animationLength; tick++) {
-            groupComponent.onTick(currentFrameView, persistentFrames);
+            groupComponent.onTick(currentFrameView, persistentFrames, 1);
         }
 
-        groupComponent.onUse(currentFrameView, persistentFrames);
         assertEquals(
                 INTERPOLATOR.interpolate(80, 50, indexToColor(7), indexToColor(8)),
                 currentFrameView.color(0, 0)
@@ -129,10 +128,9 @@ public final class AnimationGroupComponentTest {
 
         int animationLength = 330;
         for (int tick = 0; tick < animationLength; tick++) {
-            groupComponent.onTick(currentFrameView, persistentFrames);
+            groupComponent.onTick(currentFrameView, persistentFrames, 1);
         }
 
-        groupComponent.onUse(currentFrameView, persistentFrames);
         assertEquals(
                 INTERPOLATOR.interpolate(80, 50, indexToColor(17), indexToColor(18)),
                 currentFrameView.color(0, 0)
@@ -215,10 +213,9 @@ public final class AnimationGroupComponentTest {
 
         int animationLength = 330;
         for (int tick = 0; tick < animationLength; tick++) {
-            groupComponent.onTick(currentFrameView, persistentFrames);
+            groupComponent.onTick(currentFrameView, persistentFrames, 1);
         }
 
-        groupComponent.onUse(currentFrameView, persistentFrames);
         assertEquals(
                 INTERPOLATOR.interpolate(80, 50, indexToColor(7), indexToColor(8)),
                 currentFrameView.color(9, 19)

--- a/common/src/test/java/io/github/moremcmeta/animationplugin/metadata/AnimationComponentBuilderTest.java
+++ b/common/src/test/java/io/github/moremcmeta/animationplugin/metadata/AnimationComponentBuilderTest.java
@@ -116,11 +116,13 @@ public final class AnimationComponentBuilderTest {
         );
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
+        MockPersistentFrameGroup persistentFrameGroup = new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames());
 
         for (int expectedFrame = 1; expectedFrame < 6; expectedFrame++) {
             for (int tick = 0; tick < time; tick++) {
-                component.onTick(currentFrameView, new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames()));
+                component.onTick(currentFrameView, persistentFrameGroup);
             }
+            component.onUse(currentFrameView, persistentFrameGroup);
             assertEquals(indexToColor(expectedFrame % MOCK_FRAME_GROUP.get().frames()), currentFrameView.color(0, 0));
         }
     }
@@ -141,12 +143,14 @@ public final class AnimationComponentBuilderTest {
         );
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
+        MockPersistentFrameGroup persistentFrameGroup = new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames());
 
         for (int expectedFrame = 1; expectedFrame < 6; expectedFrame++) {
             int time = LARGE_MOCK_FRAME_LIST.get((expectedFrame - 1) % LARGE_MOCK_FRAME_LIST.size()).rightInt();
             for (int tick = 0; tick < time; tick++) {
-                component.onTick(currentFrameView, new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames()));
+                component.onTick(currentFrameView, persistentFrameGroup);
             }
+            component.onUse(currentFrameView, persistentFrameGroup);
             assertEquals(
                     indexToColor(LARGE_MOCK_FRAME_LIST.get(expectedFrame % LARGE_MOCK_FRAME_LIST.size()).leftInt()),
                     currentFrameView.color(0, 0)
@@ -170,12 +174,14 @@ public final class AnimationComponentBuilderTest {
         );
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
+        MockPersistentFrameGroup persistentFrameGroup = new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames());
 
         for (int expectedFrame = 1; expectedFrame < 6; expectedFrame++) {
             int time = SMALL_MOCK_FRAME_LIST.get((expectedFrame - 1) % SMALL_MOCK_FRAME_LIST.size()).rightInt();
             for (int tick = 0; tick < time; tick++) {
-                component.onTick(currentFrameView, new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames()));
+                component.onTick(currentFrameView, persistentFrameGroup);
             }
+            component.onUse(currentFrameView, persistentFrameGroup);
             assertEquals(
                     indexToColor(SMALL_MOCK_FRAME_LIST.get(expectedFrame % SMALL_MOCK_FRAME_LIST.size()).leftInt()),
                     currentFrameView.color(0, 0)
@@ -204,6 +210,7 @@ public final class AnimationComponentBuilderTest {
             for (int tick = 0; tick < time; tick++) {
                 component.onTick(currentFrameView, new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames()));
             }
+            component.onUse(currentFrameView, new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames()));
             assertEquals(indexToColor(expectedFrame % MOCK_FRAME_GROUP.get().frames()), currentFrameView.color(0, 0));
         }
     }
@@ -224,12 +231,14 @@ public final class AnimationComponentBuilderTest {
         );
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
+        MockPersistentFrameGroup persistentFrameGroup = new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames());
 
         for (int expectedFrame = 1; expectedFrame < 6; expectedFrame++) {
             int time = LARGE_MOCK_FRAME_LIST.get((expectedFrame - 1) % LARGE_MOCK_FRAME_LIST.size()).rightInt();
             for (int tick = 0; tick < time; tick++) {
-                component.onTick(currentFrameView, new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames()));
+                component.onTick(currentFrameView, persistentFrameGroup);
             }
+            component.onUse(currentFrameView, persistentFrameGroup);
             assertEquals(
                     indexToColor(LARGE_MOCK_FRAME_LIST.get(expectedFrame % LARGE_MOCK_FRAME_LIST.size()).leftInt()),
                     currentFrameView.color(0, 0)
@@ -253,12 +262,14 @@ public final class AnimationComponentBuilderTest {
         );
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
+        MockPersistentFrameGroup persistentFrameGroup = new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames());
 
         for (int expectedFrame = 1; expectedFrame < 6; expectedFrame++) {
             int time = SMALL_MOCK_FRAME_LIST.get((expectedFrame - 1) % SMALL_MOCK_FRAME_LIST.size()).rightInt();
             for (int tick = 0; tick < time; tick++) {
-                component.onTick(currentFrameView, new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames()));
+                component.onTick(currentFrameView, persistentFrameGroup);
             }
+            component.onUse(currentFrameView, persistentFrameGroup);
             assertEquals(
                     indexToColor(SMALL_MOCK_FRAME_LIST.get(expectedFrame % SMALL_MOCK_FRAME_LIST.size()).leftInt()),
                     currentFrameView.color(0, 0)
@@ -349,10 +360,12 @@ public final class AnimationComponentBuilderTest {
         );
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
+        MockPersistentFrameGroup persistentFrameGroup = new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames());
         DefaultAlphaInterpolator interpolator = new DefaultAlphaInterpolator();
 
         for (int tick = 1; tick < time; tick++) {
-            component.onTick(currentFrameView, new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames()));
+            component.onTick(currentFrameView, persistentFrameGroup);
+            component.onUse(currentFrameView, persistentFrameGroup);
             assertEquals(
                     interpolator.interpolate(time, tick, indexToColor(0), indexToColor(1)),
                     currentFrameView.color(0, 1)
@@ -376,10 +389,12 @@ public final class AnimationComponentBuilderTest {
         );
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
+        MockPersistentFrameGroup persistentFrameGroup = new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames());
         SmoothAlphaInterpolator interpolator = new SmoothAlphaInterpolator();
 
         for (int tick = 1; tick < time; tick++) {
-            component.onTick(currentFrameView, new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames()));
+            component.onTick(currentFrameView, persistentFrameGroup);
+            component.onUse(currentFrameView, persistentFrameGroup);
             assertEquals(
                     interpolator.interpolate(time, tick, indexToColor(0), indexToColor(1)),
                     currentFrameView.color(0, 1)
@@ -507,10 +522,12 @@ public final class AnimationComponentBuilderTest {
         );
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
+        MockPersistentFrameGroup persistentFrameGroup = new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames());
         DefaultAlphaInterpolator interpolator = new DefaultAlphaInterpolator();
 
         for (int tick = 1; tick < time; tick++) {
-            component.onTick(currentFrameView, new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames()));
+            component.onTick(currentFrameView, persistentFrameGroup);
+            component.onUse(currentFrameView, persistentFrameGroup);
             assertEquals(
                     interpolator.interpolate(time, tick, indexToColor(10), indexToColor(11)),
                     currentFrameView.color(1, 1)
@@ -608,6 +625,7 @@ public final class AnimationComponentBuilderTest {
         );
 
         MockCurrentFrameView currentFrameView = new MockCurrentFrameView();
+        MockPersistentFrameGroup persistentFrameGroup = new MockPersistentFrameGroup(frameGroup.frames());
 
         Set<Long> changedPoints = new HashSet<>();
         Set<Integer> nonInterpolatedColors = Set.of(
@@ -618,7 +636,8 @@ public final class AnimationComponentBuilderTest {
         );
         for (int frame = 0; frame < frameGroup.frames(); frame++) {
             for (int tick = 0; tick < time; tick++) {
-                component.onTick(currentFrameView, new MockPersistentFrameGroup(frameGroup.frames()));
+                component.onTick(currentFrameView, persistentFrameGroup);
+                component.onUse(currentFrameView, persistentFrameGroup);
 
                 for (int y = 0; y < currentFrameView.height(); y++) {
                     for (int x = 0; x < currentFrameView.width(); x++) {

--- a/common/src/test/java/io/github/moremcmeta/animationplugin/metadata/AnimationComponentBuilderTest.java
+++ b/common/src/test/java/io/github/moremcmeta/animationplugin/metadata/AnimationComponentBuilderTest.java
@@ -120,9 +120,8 @@ public final class AnimationComponentBuilderTest {
 
         for (int expectedFrame = 1; expectedFrame < 6; expectedFrame++) {
             for (int tick = 0; tick < time; tick++) {
-                component.onTick(currentFrameView, persistentFrameGroup);
+                component.onTick(currentFrameView, persistentFrameGroup, 1);
             }
-            component.onUse(currentFrameView, persistentFrameGroup);
             assertEquals(indexToColor(expectedFrame % MOCK_FRAME_GROUP.get().frames()), currentFrameView.color(0, 0));
         }
     }
@@ -148,9 +147,8 @@ public final class AnimationComponentBuilderTest {
         for (int expectedFrame = 1; expectedFrame < 6; expectedFrame++) {
             int time = LARGE_MOCK_FRAME_LIST.get((expectedFrame - 1) % LARGE_MOCK_FRAME_LIST.size()).rightInt();
             for (int tick = 0; tick < time; tick++) {
-                component.onTick(currentFrameView, persistentFrameGroup);
+                component.onTick(currentFrameView, persistentFrameGroup, 1);
             }
-            component.onUse(currentFrameView, persistentFrameGroup);
             assertEquals(
                     indexToColor(LARGE_MOCK_FRAME_LIST.get(expectedFrame % LARGE_MOCK_FRAME_LIST.size()).leftInt()),
                     currentFrameView.color(0, 0)
@@ -179,9 +177,8 @@ public final class AnimationComponentBuilderTest {
         for (int expectedFrame = 1; expectedFrame < 6; expectedFrame++) {
             int time = SMALL_MOCK_FRAME_LIST.get((expectedFrame - 1) % SMALL_MOCK_FRAME_LIST.size()).rightInt();
             for (int tick = 0; tick < time; tick++) {
-                component.onTick(currentFrameView, persistentFrameGroup);
+                component.onTick(currentFrameView, persistentFrameGroup, 1);
             }
-            component.onUse(currentFrameView, persistentFrameGroup);
             assertEquals(
                     indexToColor(SMALL_MOCK_FRAME_LIST.get(expectedFrame % SMALL_MOCK_FRAME_LIST.size()).leftInt()),
                     currentFrameView.color(0, 0)
@@ -208,9 +205,8 @@ public final class AnimationComponentBuilderTest {
 
         for (int expectedFrame = 1; expectedFrame < 6; expectedFrame++) {
             for (int tick = 0; tick < time; tick++) {
-                component.onTick(currentFrameView, new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames()));
+                component.onTick(currentFrameView, new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames()), 1);
             }
-            component.onUse(currentFrameView, new MockPersistentFrameGroup(MOCK_FRAME_GROUP.get().frames()));
             assertEquals(indexToColor(expectedFrame % MOCK_FRAME_GROUP.get().frames()), currentFrameView.color(0, 0));
         }
     }
@@ -236,9 +232,8 @@ public final class AnimationComponentBuilderTest {
         for (int expectedFrame = 1; expectedFrame < 6; expectedFrame++) {
             int time = LARGE_MOCK_FRAME_LIST.get((expectedFrame - 1) % LARGE_MOCK_FRAME_LIST.size()).rightInt();
             for (int tick = 0; tick < time; tick++) {
-                component.onTick(currentFrameView, persistentFrameGroup);
+                component.onTick(currentFrameView, persistentFrameGroup, 1);
             }
-            component.onUse(currentFrameView, persistentFrameGroup);
             assertEquals(
                     indexToColor(LARGE_MOCK_FRAME_LIST.get(expectedFrame % LARGE_MOCK_FRAME_LIST.size()).leftInt()),
                     currentFrameView.color(0, 0)
@@ -267,9 +262,8 @@ public final class AnimationComponentBuilderTest {
         for (int expectedFrame = 1; expectedFrame < 6; expectedFrame++) {
             int time = SMALL_MOCK_FRAME_LIST.get((expectedFrame - 1) % SMALL_MOCK_FRAME_LIST.size()).rightInt();
             for (int tick = 0; tick < time; tick++) {
-                component.onTick(currentFrameView, persistentFrameGroup);
+                component.onTick(currentFrameView, persistentFrameGroup, 1);
             }
-            component.onUse(currentFrameView, persistentFrameGroup);
             assertEquals(
                     indexToColor(SMALL_MOCK_FRAME_LIST.get(expectedFrame % SMALL_MOCK_FRAME_LIST.size()).leftInt()),
                     currentFrameView.color(0, 0)
@@ -364,8 +358,7 @@ public final class AnimationComponentBuilderTest {
         DefaultAlphaInterpolator interpolator = new DefaultAlphaInterpolator();
 
         for (int tick = 1; tick < time; tick++) {
-            component.onTick(currentFrameView, persistentFrameGroup);
-            component.onUse(currentFrameView, persistentFrameGroup);
+            component.onTick(currentFrameView, persistentFrameGroup, 1);
             assertEquals(
                     interpolator.interpolate(time, tick, indexToColor(0), indexToColor(1)),
                     currentFrameView.color(0, 1)
@@ -393,8 +386,7 @@ public final class AnimationComponentBuilderTest {
         SmoothAlphaInterpolator interpolator = new SmoothAlphaInterpolator();
 
         for (int tick = 1; tick < time; tick++) {
-            component.onTick(currentFrameView, persistentFrameGroup);
-            component.onUse(currentFrameView, persistentFrameGroup);
+            component.onTick(currentFrameView, persistentFrameGroup, 1);
             assertEquals(
                     interpolator.interpolate(time, tick, indexToColor(0), indexToColor(1)),
                     currentFrameView.color(0, 1)
@@ -526,8 +518,7 @@ public final class AnimationComponentBuilderTest {
         DefaultAlphaInterpolator interpolator = new DefaultAlphaInterpolator();
 
         for (int tick = 1; tick < time; tick++) {
-            component.onTick(currentFrameView, persistentFrameGroup);
-            component.onUse(currentFrameView, persistentFrameGroup);
+            component.onTick(currentFrameView, persistentFrameGroup, 1);
             assertEquals(
                     interpolator.interpolate(time, tick, indexToColor(10), indexToColor(11)),
                     currentFrameView.color(1, 1)
@@ -636,8 +627,7 @@ public final class AnimationComponentBuilderTest {
         );
         for (int frame = 0; frame < frameGroup.frames(); frame++) {
             for (int tick = 0; tick < time; tick++) {
-                component.onTick(currentFrameView, persistentFrameGroup);
-                component.onUse(currentFrameView, persistentFrameGroup);
+                component.onTick(currentFrameView, persistentFrameGroup, 1);
 
                 for (int y = 0; y < currentFrameView.height(); y++) {
                     for (int x = 0; x < currentFrameView.width(); x++) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ maven_group = io.github.moremcmeta
 
 # MoreMcmeta version to use for development. If you are not developing a
 # default plugin, use a stable release version instead.
-moremcmeta_version = 1.20.1-4.x-1.20-SNAPSHOT
+moremcmeta_version = 1.20.1-4.x-1.20-large-frame-performance-SNAPSHOT
 
 # Minimum MoreMcmeta version that users can install. This should be at
 # least 4.0.0 for the corresponding Minecraft version if this plugin is

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ maven_group = io.github.moremcmeta
 
 # MoreMcmeta version to use for development. If you are not developing a
 # default plugin, use a stable release version instead.
-moremcmeta_version = 1.20.1-4.x-1.20-large-frame-performance-SNAPSHOT
+moremcmeta_version = 1.20.1-4.x-1.20-SNAPSHOT
 
 # Minimum MoreMcmeta version that users can install. This should be at
 # least 4.0.0 for the corresponding Minecraft version if this plugin is


### PR DESCRIPTION
## What did you change?
Made the plugin compute animation frames when the texture as used, rather than every tick.

## Why did you make this change?
Improves performance since most textures aren't in use at the same time.

## How did you make this change?
Changed the `AnimationGroupComponent` and `AnimationComponent` to use the new `onTick()` handler from MoreMcmeta/core#43 that runs at least as often as the texture is updated. `AnimationState` already supported moving the animation ahead by several ticks at a time.

## How can others see the effect of your change?
See MoreMcmeta/core#43.

## Links to related issues
MoreMcmeta/core#39

## Which Minecraft versions does this change apply to?
1.20

## Did you test this change on both mod loaders?
- [x] Forge
- [x] Fabric

## Did you unit test this change?
- [x] I unit tested this change.
- [ ] This change is too small to warrant any new unit tests.
- [ ] Other (Please explain below.)

## Areas for improvement (if any)
N/A

## Additional notes (if any)
Will be cherry-picked to older MC versions.